### PR TITLE
Fix OpenAI connection test await

### DIFF
--- a/utils/openai.js
+++ b/utils/openai.js
@@ -384,10 +384,10 @@ const testConnection = async (apiKey) => {
       }))
       .sort((a, b) => b.created - a.created); // Sort newest first
     
-    // Cache API key in Redis for future use
+    // Cache API key in Redis for future use (implementation removed)
     try {
-      await // Redis client usage removed. Use PostgreSQL or environment variables.set(OPENAI_API_KEY_REDIS_KEY, apiKey);
-      logger.debug('Cached tested API key in Redis');
+      // await redisClient.set(OPENAI_API_KEY_REDIS_KEY, apiKey);
+      // logger.debug('Cached tested API key in Redis');
     } catch (redisError) {
       logger.warn('Failed to cache tested API key in Redis', redisError);
     }


### PR DESCRIPTION
## Summary
- remove stray await from `testConnection` in OpenAI helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841020ef03083288f479652bb35e128