### PR TITLE
docs: clarify LLM provider source in scheduler

### DIFF
--- a/utils/scheduler.js
+++ b/utils/scheduler.js
@@ -87,7 +87,7 @@ const checkOllamaStatus = async () => {
  */
 const checkApiStatus = async () => {
   try {
-    // Get the current LLM provider from Redis
+    // Get the current LLM provider from settings
     let currentProvider = 'openai'; // Default if not set
     
     try {


### PR DESCRIPTION
## Summary
- clarify comment about reading the current LLM provider from settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684102ac0adc832895070075d4a92915