### PR TITLE
Add database-backed logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This is an enhanced threat modeling platform that integrates structured project 
 - **Database Persistence**: PostgreSQL backend for robust data integrity and complex relationship management.
 - **AI-Powered Analysis**: OpenAI integration for generating detailed threat analyses and remediation recommendations.
 - **Component Library**: Reusable component catalog for consistent threat modeling across projects.
+- **Centralized Logging**: Application logs are persisted to PostgreSQL when running in production.
 
 ## Prerequisites
 
@@ -90,6 +91,7 @@ The application uses a PostgreSQL database with the following main tables:
 - `vulnerabilities`: Real-world vulnerabilities imported from scanning tools
 - `threats`: Identified potential threats with risk assessment
 - `threat_models`: Structured threat modeling documents
+- `app_logs`: Application logs persisted when running in production
 
 ### Integration Points
 - **Rapid7**: Imports vulnerability data to correlate with threat models

--- a/database/migrations/20250615_create_app_logs_table.sql
+++ b/database/migrations/20250615_create_app_logs_table.sql
@@ -1,0 +1,15 @@
+-- Migration: Create app_logs table to store application logs
+CREATE SCHEMA IF NOT EXISTS threat_model;
+
+CREATE TABLE IF NOT EXISTS threat_model.app_logs (
+    id SERIAL PRIMARY KEY,
+    timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    level VARCHAR(10) NOT NULL,
+    module VARCHAR(255),
+    message TEXT NOT NULL,
+    data TEXT,
+    error TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_app_logs_level ON threat_model.app_logs(level);
+CREATE INDEX IF NOT EXISTS idx_app_logs_module ON threat_model.app_logs(module);


### PR DESCRIPTION
## Summary
- log messages to `app_logs` table in production
- expose log queries from database when retrieving logs
- document centralized logging in README
- add `app_logs` migration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684109f6c404832890ab005cbe83dc53